### PR TITLE
14 api add a system to make tables available again

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,6 +136,13 @@ def clear_all_tables():
         cursor.execute(q.CLEAR_ALL_RESERVATIONS)
         connection.commit()
         # TODO: Cancel all active countdowns
+        try:
+            for this_task in TASK_DICT.values():
+                task = this_task
+                task.cancel()
+            TASK_DICT.clear()
+        except:
+            pass
         return {'success': True, 'message': 'Tables all cleared successfully'}
     except Exception as e:
         print(f"Error: {e}")

--- a/app.py
+++ b/app.py
@@ -84,7 +84,29 @@ def clear_table(table_number: int):
             cursor = connection.cursor()
             cursor.execute(q.CLEAR_RESERVATION, (table_number,))
             connection.commit()
-            return {'success': True, 'message': 'Table reserved successfully'}
+            return {'success': True, 'message': 'Table cleared successfully'}
+    except Exception as e:
+        print(f"Error: {e}")
+        return {'error': 'Internal Server Error'}, 500
+    finally:
+        pool.release_connection(connection)
+
+"""
+This route can be called to make all table ready to be reserved again. Calls CLEAR_ALL_RESERVATIONS in queries.py
+
+Returns:
+        Success message on success
+        Error message on Error
+"""
+@app.post('/table/clear_all/')
+def clear_all_tables():
+
+    try:
+        connection = pool.get_connection()
+        cursor = connection.cursor()
+        cursor.execute(q.CLEAR_ALL_RESERVATIONS)
+        connection.commit()
+        return {'success': True, 'message': 'Tables all cleared successfully'}
     except Exception as e:
         print(f"Error: {e}")
         return {'error': 'Internal Server Error'}, 500

--- a/queries.py
+++ b/queries.py
@@ -6,6 +6,8 @@ SET_RESERVATION = "UPDATE public.table SET table_available = False WHERE table_i
 
 CLEAR_RESERVATION = "UPDATE public.table SET table_available = True WHERE table_id = %s;"
 
+CLEAR_ALL_RESERVATIONS = "UPDATE public.table SET table_available = True;"
+
 SELECT_RESERVATION = "SELECT * FROM public.table WHERE table_id = %s;"
 
 GET_TABLE_INFO = "SELECT * FROM public.table ORDER BY table_id;"


### PR DESCRIPTION
Added functionality to cancel reservations one hour after setting. Manual clearing will clear out countdowns. 
Added /table/clear_all/ endpoint to reset all tables availability also clears all countdowns and empties task dictionary